### PR TITLE
修正首頁按鈕 hover 樣式

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -59,6 +59,10 @@
     @apply border border-black text-black px-4 py-2 hover:bg-gray-100 transition;
   }
 
+  .btn-outline-white {
+    @apply border border-white text-white px-4 py-2 bg-transparent hover:bg-gray-100 hover:text-black transition;
+  }
+
   .tag-red {
     @apply bg-democratic-red text-white text-xs px-2 py-1 inline-block;
   }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -47,7 +47,7 @@ useHead({
             <router-link to="/topics" class="btn-primary rounded-md">
               {{ $t('home.hero.buttons.browseTopics') }}
             </router-link>
-            <router-link to="/intro" class="btn-outline bg-transparent text-white border-white rounded-md">
+            <router-link to="/intro" class="btn-outline-white rounded-md">
               {{ $t('home.hero.buttons.learnMore') }}
             </router-link>
           </div>
@@ -99,7 +99,7 @@ useHead({
           <router-link to="/topics" class="btn-primary rounded-md">
             {{ $t('home.cta.buttons.browseTopics') }}
           </router-link>
-          <router-link to="/intro" class="btn-outline bg-transparent text-white border-white rounded-md">
+          <router-link to="/intro" class="btn-outline-white rounded-md">
             {{ $t('home.cta.buttons.learnMore') }}
           </router-link>
         </div>


### PR DESCRIPTION
首頁“了解更多”按鈕 hover 後，文字顏色與背景顏色相近。這個 pr 加入 .btn-outline-white 按鈕樣式用於首頁黑色背影區域

Before:
![1760492454742](https://github.com/user-attachments/assets/98e2e2f6-3485-4cde-8644-c7447f165f0d)

After:
![1760492457556](https://github.com/user-attachments/assets/13df435d-c9cd-49f6-b91f-b69f30d6c4dc)
