### PR TITLE
修正 Android 中 chrome 瀏覽器被判定為 in-app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@unhead/vue": "2.0.12",
         "axios": "^1.9.0",
-        "detect-inapp": "^1.4.0",
         "firebase": "^11.9.0",
+        "inapp-spy": "^5.0.6",
         "lucide-vue-next": "^0.514.0",
         "marked": "^15.0.12",
         "vue": "^3.4.0",
@@ -3047,15 +3047,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/detect-inapp": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/detect-inapp/-/detect-inapp-1.4.0.tgz",
-      "integrity": "sha512-2S29Udznzsno138s33j/yR/9uzFU25rt/1DWecnpoj5oCmjvsCt4tFe+6go6drTyuLodz7ZNQSGbl17cDDx/+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.5"
-      }
-    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -3689,6 +3680,12 @@
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
     },
+    "node_modules/inapp-spy": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/inapp-spy/-/inapp-spy-5.0.6.tgz",
+      "integrity": "sha512-Ic+YHicF2qtn0PTezUCLtcB/qDyPDUXSp+2EwYjLOLUupagnfPQSqtYsO3paVsxSWNVj/EkCpLIDvx67NqPZvg==",
+      "license": "MIT"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3967,12 +3964,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -11,17 +11,17 @@
     "type-check": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "@unhead/vue": "2.0.12",
     "axios": "^1.9.0",
-    "detect-inapp": "^1.4.0",
     "firebase": "^11.9.0",
+    "inapp-spy": "^5.0.6",
     "lucide-vue-next": "^0.514.0",
     "marked": "^15.0.12",
     "vue": "^3.4.0",
     "vue-gtag-next": "^1.14.0",
     "vue-i18n": "^9.14.4",
     "vue-router": "^4.2.5",
-    "vue3-carousel": "^0.16.0",
-    "@unhead/vue": "2.0.12"
+    "vue3-carousel": "^0.16.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,7 +26,7 @@
           </button>
         </div>
 
-        <GoogleLogin @login-success="handleLoginSuccess" :inApp="actualInApp" />
+        <GoogleLogin @login-success="handleLoginSuccess" :inApp="isInApp" />
 
         <div class="mt-4 text-center">
           <button @click="showLoginModal = false" class="text-gray-500 hover:text-gray-700">
@@ -50,13 +50,9 @@ import IconWrapper from './components/IconWrapper.vue'
 import { database, usersRef } from './lib/firebase'
 import { ref as dbRef, get, set, update } from 'firebase/database'
 
-import InApp from 'detect-inapp'; // 導入InApp以偵測瀏覽器內部環境
+import InAppSpy from 'inapp-spy'
 
-const inApp = new InApp(window.navigator.userAgent);
-  // 初始假設為 InApp 庫的偵測結果
-const actualInApp = inApp.isInApp;
-
-
+const { isInApp } = InAppSpy()
 const { t } = useI18n()
 
 const user = ref(null)


### PR DESCRIPTION
Fix #108 

檢查後發現是 detect-inapp 套件會錯誤判斷 Android 中的 chrome 瀏覽器，導致 inApp 返回 true，直接顯示 alert 訊息: "本系統不支援Facebook, Line等app內部瀏覽，請用一般瀏覽器開啟，方可登入，謝謝"

detect-inapp 套件中的 [issue #52](https://github.com/f2etw/detect-inapp/issues/52) 有討論到這個問題，但目前似乎還沒修正

這個 PR 改用 [issue 最後 shalanah 提供的新套件](https://github.com/f2etw/detect-inapp/issues/52#issuecomment-1937394332)，目前測試 inApp 判斷正常