### PR TITLE
修正導航 z-index 層級，避免蓋過登入彈窗

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@
     <Footer />
 
     <!-- 登入模態框 -->
-    <div v-if="showLoginModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+    <div v-if="showLoginModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[9999]">
       <div class="bg-white rounded-lg p-8 max-w-md w-full mx-4">
         <div class="flex justify-between items-center mb-6">
           <h2 class="text-2xl font-bold">{{ $t('auth.loginTitle') }}</h2>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <header id="navbar"class="bg-black text-white sticky top-0 z-10">
+  <header class="bg-black text-white sticky top-0 z-[999]">
     <div class="w-full px-4 md:mx-auto">
       <div class="flex justify-between items-center h-16">
         <router-link to="/" class="flex items-center">
@@ -129,10 +129,6 @@ const handleShowLogin = () => {
 </script>
 
 <style scoped>
-/* Header styles */
-#navbar {
-  z-index: 999;
-}
 /* 使用 router-link-exact-active class 來標示當前路由 */
 .router-link-exact-active {
   color: #D82000 !important; /* democratic-red 顏色 */


### PR DESCRIPTION
手機版在打開導航選單後，點選"登入"，此時登入彈窗會出現在導行選單的後面，主要是因為 #navbar 設定 z-index: 999，拿掉就會正常

此設定是在 [Commit c293965](https://github.com/g0v/vue.vTaiwan-neo/commit/c293965) 修改，想順便確認這個 commit 是為了解決什麼問題，需要做其他調整嗎?

Before:
![1760679229494](https://github.com/user-attachments/assets/366eae35-f394-4c02-ba5e-ec73e5751b2f)

After:
![1760679227460](https://github.com/user-attachments/assets/65a65e84-0404-460b-b72c-6d9d32795ebb)
