### PR TITLE
修正議題內容頁中外部相關連結 icon

### DIFF
--- a/src/components/ParticipationLink.vue
+++ b/src/components/ParticipationLink.vue
@@ -10,7 +10,7 @@
         :title="item.long"
         class="inline-flex items-center px-3 py-1 text-sm bg-jade-green text-white rounded hover:bg-jade-green/80 transition-colors"
       >
-        <IconWrapper :name="item.icon" :size="14" class="mr-1" />
+        <IconWrapper :name="item.icon" :size="14" class="mr-1 flex-shrink-0" color="white" />
         {{ item.text }}
       </a>
     </div>


### PR DESCRIPTION
 - 避免 icon 因為文字太長而被壓縮
 - icon 改成白色 (與文字相同)

Before:
<img src="https://github.com/user-attachments/assets/13e1ed4f-e999-49fe-8a81-f9a023a30c79" width="300px"/>

After:
<img src="https://github.com/user-attachments/assets/a52bf947-d1d5-44af-b1da-eb8ce74f11b9" width="300px"/>
