### PR TITLE
Header 點擊 Logo 後，關閉手機導航選單

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -2,7 +2,7 @@
   <header class="bg-black text-white sticky top-0 z-[999]">
     <div class="w-full px-4 md:mx-auto">
       <div class="flex justify-between items-center h-16">
-        <router-link to="/" class="flex items-center">
+        <router-link to="/" class="flex items-center" @click="mobileMenuOpen = false">
           <img src="@/assets/images/vtaiwan-logo.svg" alt="vTaiwan Logo" class="h-8 w-auto" />
         </router-link>
 


### PR DESCRIPTION
手機版在開著導航時，點擊 Logo 按鈕跳回首頁，導航列會保持開啟狀態。這個 PR 改成在點擊 Logo 同時關閉手機導航列

Before
https://github.com/user-attachments/assets/a3138c1a-5840-4a04-b567-92868ecee1da

After
https://github.com/user-attachments/assets/29c5c052-68a5-4819-a719-170c53b0d586

